### PR TITLE
improve installExtension task as VS code 1.4.0 is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is an Example showing the Visual Studio Code integration of Xtext using the
 
 ## Quickstart
 
-Requires Visual Studio Code (VS Code) to be on the path as `code` and Java 8+ available as `java`.
+Requires Visual Studio Code (VS Code) with version 1.4.0 or greater to be on the path as `code` and Java 8+ available as `java`.
 
 - Run `./gradlew startCode`
 

--- a/vscode-extension-self-contained/build.gradle
+++ b/vscode-extension-self-contained/build.gradle
@@ -1,19 +1,11 @@
-/**
- * Problem: right now we cannot install the plugin in a headless mode.
- * That's why we need this hacky task...
- * @see https://github.com/Microsoft/vscode/issues/9585
- */
 task installExtension(type: Exec, dependsOn: vscodeExtension) {
     commandLine 'code'
-    args vscodeExtension.destPath, '--new-window'
-    doLast {
-        Thread.sleep(5000)
-    }
+    args '--install-extension', vscodeExtension.destPath
 }
 
 task startCode(type:Exec, dependsOn: installExtension) {
     commandLine 'code'
-    args "$rootProject.projectDir/demo/", '--reuse-window'
+    args "$rootProject.projectDir/demo/", '--new-window'
 }
 
 task publish(dependsOn: vscodeExtension, type: NodeTask) {


### PR DESCRIPTION
With VS code 1.4.0 we can use the headless installation of the extension using `--install-extension`.

Issue https://github.com/Microsoft/vscode/issues/9585 is resolved in this release.