### PR TITLE
Fix build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ buildscript {
 apply plugin: 'com.github.node-gradle.node'
 apply plugin: 'net.researchgate.release'
 node {
-	version = '10.16.0'
-	npmVersion = '6.10.2'
+	version = '16.13.2'
+	npmVersion = '8.3.0'
 	download = true
 }
 
@@ -75,8 +75,8 @@ configure(subprojects.findAll { it.name.startsWith('vscode') }) {
 
 	apply plugin: 'com.github.node-gradle.node'
 	node {
-	    version = '10.16.0'
-	    npmVersion = '6.10.2'
+	    version = '16.13.2'
+	    npmVersion = '8.3.0'
 	    download = true
 	}
 
@@ -102,7 +102,7 @@ configure(subprojects.findAll { it.name.startsWith('vscode') }) {
 		doFirst {
 			destDir.mkdirs()
 		}
-		script = file("$npmInstallVsce.destPath/out/vsce")
+		script = file("$npmInstallVsce.destPath/vsce")
 		args = [ 'package', '--out', destPath ]
 		execOverrides {
 			workingDir = projectDir


### PR DESCRIPTION
This merge requests fixes the build failing on a fresh checkout. 

There are two reasons why it fails:
- The latest vsce requires Node 14+ (build fails on Node 10 due to vsce using the unsupported nullish coalescing operator). 
Source: https://github.com/microsoft/vscode-vsce#requirements
- In addition the script location has been changed (`node_modules/vsce/out/vsce` -> `node_modules/vsce/vsce`)